### PR TITLE
Add example template for accessing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ sensor:
     password: 'XXXX'
     station_id : '12345678-1234-1234-1234-123456789012'
     scan_interval: 60
+
+# create a template to access the data as "sensor.pv_outputpower"
+  - platform: template
+    sensors:
+      pv_outputpower:
+        value_template: '{{ states.sensor.sems_portal.attributes.outputpower }}'
+        unit_of_measurement: 'W'
+        friendly_name: "Power output"
+
 ```
 
 Use the credentials you use to login to https://www.semsportal.com/. 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ sensor:
     station_id : '12345678-1234-1234-1234-123456789012'
     scan_interval: 60
 
-# create a template to access the data as "sensor.pv_outputpower"
+# Optional/example
+# A template to ease access to the data as "sensor.pv_outputpower" etc.
   - platform: template
     sensors:
       pv_outputpower:


### PR DESCRIPTION
Show how to add a template to sensor configuration to make it easy to use the data obtained from sems portal.