### PR TITLE
add all time total generation from kpi

### DIFF
--- a/custom_components/sems/sensor.py
+++ b/custom_components/sems/sensor.py
@@ -84,6 +84,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
                 powerflow["sn"] = result["homKit"]["sn"]
                 #_LOGGER.debug("homeKit sn: %s", result["homKit"]["sn"])
+                # This seems more accurate than the Chart_sum
+                powerflow["all_time_generation"] = result["kpi"]["total_power"]
+
                 data["homeKit"] = powerflow
 
             #_LOGGER.debug("Resulting data: %s", data)


### PR DESCRIPTION
As per my comments on the existing issues, with homekit alone I noticed that I couldn't get a meaningful value for total generation from the existing sensor data returned. So this change is to retrieve the total_power from the kpi section of the api response.
Tested here and working fine.

![image](https://user-images.githubusercontent.com/4070868/185101529-7ccceb72-b385-4e36-ba4e-ad6b9afd2db1.png)

![image](https://user-images.githubusercontent.com/4070868/185101649-bdef96e3-600d-4853-91d3-227b968eba94.png)
