### PR TITLE
Adding power control

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,18 @@ Fill in the required configuration and it should find your inverters.
 
 Note that changed to `configuration.yaml` are no longer necessary and can be removed.
 
-### Recommended: use visitor account to login with this integration
+### Optional: control the invertor power output via the "switch" entity
+
+It is possible to temporarily pause the energy production via "downtime" functionality available on the invertor. This is exposed as a switch and can be used in your own automations.
+
+Please note that it is using an undocumented API and can take a few minutes for the invertor to pick up the change. It takes approx 60 seconds to start again when the invertor is in a downtime mode.
+
+### Recommended: use visitor account if you do not need to control the inverter
+
+In case you are only reading the inverter stats, you can use a Visitor (read-only) account.
 
 Create via the official app, or via the web portal:
-Login to www.semsportal.com, go to https://semsportal.com/powerstation/stationInfonew. Create a new visitor account. 
+Login to www.semsportal.com, go to https://semsportal.com/powerstation/stationInfonew. Create a new visitor account.
 Login to the visitor account once to accept the EULA. Now you should be able to use it in this component.
 
 ### Extra (optional) templates to easy access data as sensors
@@ -78,7 +86,7 @@ Replace `$NAME` with your inverter entity id.
         friendly_name: "Battery power"
 ```
 
-Note that `states.sensor.inverter_$NAME.state` contains the power output in `W`. 
+Note that `states.sensor.inverter_$NAME.state` contains the power output in `W`.
 
 ## Screenies
 

--- a/custom_components/sems/__init__.py
+++ b/custom_components/sems/__init__.py
@@ -14,7 +14,7 @@ from .const import DOMAIN
 from .sems_api import SemsApi
 
 # For your initial PR, limit it to 1 platform.
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "switch"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict):

--- a/custom_components/sems/manifest.json
+++ b/custom_components/sems/manifest.json
@@ -8,5 +8,5 @@
   "requirements": [],
   "dependencies": [],
   "codeowners": ["@TimSoethout"],
-  "version": "3.7.4"
+  "version": "5.0.0"
 }

--- a/custom_components/sems/sems_api.py
+++ b/custom_components/sems/sems_api.py
@@ -163,16 +163,16 @@ class SemsApi:
 
             data = {
                 "InverterSN": inverterSn,
-                "InverterStatusSettingMark":1,
-                "InverterStatus": status
+                "InverterStatusSettingMark":"1",
+                "InverterStatus": str(status)
             }
 
             response = requests.post(
-                powerControlURL, headers=headers, data=data, timeout=_RequestTimeout
+                powerControlURL, headers=headers, json=data, timeout=_RequestTimeout
             )
             if (response.status_code != 200):
                 # try again and renew token is unsuccessful
-                _LOGGER.debug(
+                _LOGGER.warn(
                     "Power control command not successful, retrying with new token, %s retries remaining",
                     maxTokenRetries,
                 )

--- a/custom_components/sems/sems_api.py
+++ b/custom_components/sems/sems_api.py
@@ -10,6 +10,7 @@ _LOGGER = logging.getLogger(__name__)
 # _LoginURL = "https://eu.semsportal.com/api/v2/Common/CrossLogin"
 _LoginURL = "https://www.semsportal.com/api/v2/Common/CrossLogin"
 _PowerStationURLPart = "/v2/PowerStation/GetMonitorDetailByPowerstationId"
+_GopsURL = "https://www.semsportal.com/api/PowerStation/SaveRemoteControlInverter"
 _RequestTimeout = 30  # seconds
 
 _DefaultHeaders = {
@@ -127,6 +128,63 @@ class SemsApi:
             return jsonResponse["data"]
         except Exception as exception:
             _LOGGER.error("Unable to fetch data from SEMS. %s", exception)
+
+    def change_status(self, powerStationId, status, renewToken=False, maxTokenRetries=2):
+        """Schedule the downtime of the station"""
+        try:
+            # Get the status of our SEMS Power Station
+            _LOGGER.debug("SEMS - Making Power Station Status API Call")
+            if maxTokenRetries <= 0:
+                _LOGGER.info(
+                    "SEMS - Maximum token fetch tries reached, aborting for now"
+                )
+                raise OutOfRetries
+            if self._token is None or renewToken:
+                _LOGGER.debug(
+                    "API token not set (%s) or new token requested (%s), fetching",
+                    self._token,
+                    renewToken,
+                )
+                self._token = self.getLoginToken(self._username, self._password)
+
+            # Prepare Power Station status Headers
+            headers = {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "token": json.dumps(self._token),
+            }
+
+            gopsURL = _GopsURL
+            _LOGGER.debug(
+                "Sending GOPS command (%s) for power station id: %s",
+                gopsURL,
+                powerStationId,
+            )
+
+            data = {
+                "api":"PowerStation/SaveRemoteControlInverter",
+                "param": {
+                    "InverterSN":"",
+                    "StationID":powerStationId,
+                    "InverterStatusSettingMark":1,
+                    "InverterStatus":status
+                }
+            }
+
+            response = requests.post(
+                gopsURL, headers=headers, data=data, timeout=_RequestTimeout
+            )
+            if (response.status_code != 200):
+                # try again and renew token is unsuccessful
+                _LOGGER.debug(
+                    "GOPS command not successful, retrying with new token, %s retries remaining",
+                    maxTokenRetries,
+                )
+                return
+
+            return
+        except Exception as exception:
+            _LOGGER.error("Unable to execute GOPS command. %s", exception)
 
 
 class OutOfRetries(exceptions.HomeAssistantError):

--- a/custom_components/sems/sensor.py
+++ b/custom_components/sems/sensor.py
@@ -5,6 +5,7 @@ For more details about this platform, please refer to the documentation at
 https://github.com/TimSoethout/goodwe-sems-home-assistant
 """
 
+from typing import Coroutine
 from homeassistant.core import HomeAssistant
 import homeassistant
 import logging
@@ -24,7 +25,6 @@ from homeassistant.const import (
     DEVICE_CLASS_ENERGY,
     ENERGY_KILO_WATT_HOUR,
 )
-from homeassistant.helpers.entity import Entity
 from .const import DOMAIN, CONF_STATION_ID, DEFAULT_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
@@ -567,3 +567,4 @@ class SemsPowerflowSensor(CoordinatorEntity, SensorEntity):
         Only used by the generic entity update service.
         """
         await self.coordinator.async_request_refresh()
+

--- a/custom_components/sems/switch.py
+++ b/custom_components/sems/switch.py
@@ -1,0 +1,80 @@
+"""
+Support for power production statistics from GoodWe SEMS API.
+
+For more details about this platform, please refer to the documentation at
+https://github.com/TimSoethout/goodwe-sems-home-assistant
+"""
+
+from typing import Coroutine
+from homeassistant.core import HomeAssistant
+import homeassistant
+import logging
+
+from datetime import timedelta
+
+from homeassistant.const import (
+    CONF_SCAN_INTERVAL,
+)
+from homeassistant.helpers.entity import Entity
+from .const import DOMAIN, CONF_STATION_ID
+from homeassistant.components.switch import SwitchEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Add sensors for passed config_entry in HA."""
+    # _LOGGER.debug("hass.data[DOMAIN] %s", hass.data[DOMAIN])
+    semsApi = hass.data[DOMAIN][config_entry.entry_id]
+    stationId = config_entry.data[CONF_STATION_ID]
+
+    entities = [SemsSwitch(semsApi, stationId)]
+    async_add_entities(entities)
+
+class SemsSwitch(SwitchEntity):
+
+    def __init__(self, api, stationId):
+        super().__init__()
+        self.api = api
+        self.stationId = stationId
+        _LOGGER.info("Creating SemsSwitch with id %s", self.stationId)
+
+    # def turn_off(self, **kwargs):
+    #     _LOGGER.warn("Off " + self.stationId)
+
+    # def turn_on(self, **kwargs):
+    #     _LOGGER.warn("On " + self.stationId)
+
+    @property
+    def is_on(self) -> bool:
+        """Return entity status."""
+        return True
+
+    @property
+    def name(self) -> str:
+        """Return the name of the switch."""
+        return f"Inverter {self.stationId} Switch"
+
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self.stationId}-switch"
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {
+                # Serial numbers are unique identifiers within a specific domain
+                (DOMAIN, self.stationId)
+            },
+            "name": "Homekit",
+            "manufacturer": "GoodWe",
+        }
+
+    def async_turn_off(self, **kwargs):
+        _LOGGER.warn("Off " + self.stationId)
+        self.api.change_status(self.stationId, 0)
+
+    def async_turn_on(self, **kwargs):
+        _LOGGER.warn("On " + self.stationId)
+        self.api.change_status(self.stationId, 1)

--- a/custom_components/sems/switch.py
+++ b/custom_components/sems/switch.py
@@ -1,21 +1,17 @@
 """
-Support for power production statistics from GoodWe SEMS API.
+Support for switch controlling an output of a GoodWe SEMS inverter.
 
 For more details about this platform, please refer to the documentation at
 https://github.com/TimSoethout/goodwe-sems-home-assistant
 """
 
-from typing import Coroutine
-from homeassistant.core import HomeAssistant
-import homeassistant
 import logging
-
-from datetime import timedelta
 
 from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import UpdateFailed
 from .const import DOMAIN, CONF_STATION_ID
 from homeassistant.components.switch import SwitchEntity
 
@@ -23,58 +19,57 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    """Add sensors for passed config_entry in HA."""
-    # _LOGGER.debug("hass.data[DOMAIN] %s", hass.data[DOMAIN])
+    """Add switches for passed config_entry in HA."""
     semsApi = hass.data[DOMAIN][config_entry.entry_id]
     stationId = config_entry.data[CONF_STATION_ID]
 
-    entities = [SemsSwitch(semsApi, stationId)]
+    try:
+        result = await hass.async_add_executor_job(semsApi.getData, stationId)
+
+    except Exception as err:
+        # logging.exception("Something awful happened!")
+        raise UpdateFailed(f"Error communicating with API: {err}")
+
+    inverters = result["inverter"]
+    entities = []
+    for inverter in inverters:
+        entities.append(SemsSwitch(semsApi, inverter["invert_full"]["sn"]))
+
     async_add_entities(entities)
 
 class SemsSwitch(SwitchEntity):
 
-    def __init__(self, api, stationId):
+    def __init__(self, api, sn):
         super().__init__()
         self.api = api
-        self.stationId = stationId
-        _LOGGER.info("Creating SemsSwitch with id %s", self.stationId)
-
-    # def turn_off(self, **kwargs):
-    #     _LOGGER.warn("Off " + self.stationId)
-
-    # def turn_on(self, **kwargs):
-    #     _LOGGER.warn("On " + self.stationId)
-
-    @property
-    def is_on(self) -> bool:
-        """Return entity status."""
-        return True
+        self.sn = sn
+        _LOGGER.debug(f"Creating SemsSwitch for Inverter {self.sn}")
 
     @property
     def name(self) -> str:
         """Return the name of the switch."""
-        return f"Inverter {self.stationId} Switch"
+        return f"Inverter {self.sn} Switch"
 
 
     @property
     def unique_id(self) -> str:
-        return f"{self.stationId}-switch"
+        return f"{self.sn}-switch"
 
     @property
     def device_info(self):
         return {
             "identifiers": {
                 # Serial numbers are unique identifiers within a specific domain
-                (DOMAIN, self.stationId)
+                (DOMAIN, self.sn)
             },
             "name": "Homekit",
             "manufacturer": "GoodWe",
         }
 
     def async_turn_off(self, **kwargs):
-        _LOGGER.warn("Off " + self.stationId)
-        self.api.change_status(self.stationId, 0)
+        _LOGGER.debug(f"Inverter {self.sn} set to Off")
+        self.api.change_status(self.sn, 0)
 
     def async_turn_on(self, **kwargs):
-        _LOGGER.warn("On " + self.stationId)
-        self.api.change_status(self.stationId, 1)
+        _LOGGER.debug(f"Inverter {self.sn} set to On")
+        self.api.change_status(self.sn, 1)

--- a/custom_components/sems/switch.py
+++ b/custom_components/sems/switch.py
@@ -68,8 +68,8 @@ class SemsSwitch(SwitchEntity):
 
     def async_turn_off(self, **kwargs):
         _LOGGER.debug(f"Inverter {self.sn} set to Off")
-        self.api.change_status(self.sn, 0)
+        self.api.change_status(self.sn, 2)
 
     def async_turn_on(self, **kwargs):
         _LOGGER.debug(f"Inverter {self.sn} set to On")
-        self.api.change_status(self.sn, 1)
+        self.api.change_status(self.sn, 4)


### PR DESCRIPTION
This resolves https://github.com/TimSoethout/goodwe-sems-home-assistant/issues/87 by adding control to switch off the power generation of the invertor by using the same REST API available in the SEMS app.

One thing that's not implemented yet is getting the current "status" of the switch. This is usually several minutes delayed from the reality and I didn't consider that as an important feature at this point.

Note that this is my first:
1. PR on GitHub (always used Bitbucket)
2. change in HA plugin
3. Python code in a long time

Nonetheless, it seems that it's working. Happy to hear the feedback.