### PR TITLE
Add unexposed energy statistics and per-inverter sensors

### DIFF
--- a/custom_components/sems/sensor.py
+++ b/custom_components/sems/sensor.py
@@ -55,6 +55,16 @@ def convert_status_to_label(status: Any) -> str:
     return STATUS_LABELS.get(int(status), "Unknown")
 
 
+def _percentage_handler(value: Any, _data: dict[str, Any]) -> Any:
+    """Convert a 0-1 ratio to a percentage."""
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value)) * 100
+    except (TypeError, ValueError):
+        return value
+
+
 @dataclass(slots=True)
 class SemsSensorType:
     """SEMS sensor definition."""
@@ -396,6 +406,46 @@ def sensor_options_for_data(
                         SensorStateClass.MEASUREMENT,
                     ),
                 ]
+        # Per-inverter meter and energy data (hybrid/storage inverters)
+        if (
+            get_value_from_path(data.inverters, [*path_to_inverter, "pmeter"])
+            is not None
+        ):
+            sensors.append(
+                SemsInverterSensorType(
+                    device_info,
+                    f"{serial_number}-pmeter",
+                    [*path_to_inverter, "pmeter"],
+                    "Grid Meter Power",
+                    SensorDeviceClass.POWER,
+                    UnitOfPower.WATT,
+                    SensorStateClass.MEASUREMENT,
+                ),
+            )
+        if (
+            get_value_from_path(data.inverters, [*path_to_inverter, "eChargeDay"])
+            is not None
+        ):
+            sensors += [
+                SemsInverterSensorType(
+                    device_info,
+                    f"{serial_number}-eChargeDay",
+                    [*path_to_inverter, "eChargeDay"],
+                    "Battery Charge Today",
+                    SensorDeviceClass.ENERGY,
+                    UnitOfEnergy.KILO_WATT_HOUR,
+                    SensorStateClass.TOTAL_INCREASING,
+                ),
+                SemsInverterSensorType(
+                    device_info,
+                    f"{serial_number}-eDischargeDay",
+                    [*path_to_inverter, "eDischargeDay"],
+                    "Battery Discharge Today",
+                    SensorDeviceClass.ENERGY,
+                    UnitOfEnergy.KILO_WATT_HOUR,
+                    SensorStateClass.TOTAL_INCREASING,
+                ),
+            ]
         _LOGGER.debug("Sensors for inverter %s: %s", serial_number, sensors)
 
     # HomeKit powerflow + SEMS charts live in `SemsData.homekit`.
@@ -537,6 +587,62 @@ def sensor_options_for_data(
                         UnitOfEnergy.KILO_WATT_HOUR,
                         SensorStateClass.TOTAL_INCREASING,
                     ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-daily-load-consumption",
+                        ["Charts_consumptionOfLoad"],
+                        "SEMS Daily Load Consumption",
+                        SensorDeviceClass.ENERGY,
+                        UnitOfEnergy.KILO_WATT_HOUR,
+                        SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-daily-self-use",
+                        ["Charts_selfUseOfPv"],
+                        "SEMS Daily Self Use",
+                        SensorDeviceClass.ENERGY,
+                        UnitOfEnergy.KILO_WATT_HOUR,
+                        SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-daily-battery-charge",
+                        ["Charts_charge"],
+                        "SEMS Daily Battery Charge",
+                        SensorDeviceClass.ENERGY,
+                        UnitOfEnergy.KILO_WATT_HOUR,
+                        SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-daily-battery-discharge",
+                        ["Charts_disCharge"],
+                        "SEMS Daily Battery Discharge",
+                        SensorDeviceClass.ENERGY,
+                        UnitOfEnergy.KILO_WATT_HOUR,
+                        SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-daily-self-sufficiency-rate",
+                        ["Charts_contributingRate"],
+                        "SEMS Daily Self Sufficiency Rate",
+                        None,
+                        PERCENTAGE,
+                        SensorStateClass.MEASUREMENT,
+                        custom_value_handler=_percentage_handler,
+                    ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-daily-self-use-rate",
+                        ["Charts_selfUseRate"],
+                        "SEMS Daily Self Use Rate",
+                        None,
+                        PERCENTAGE,
+                        SensorStateClass.MEASUREMENT,
+                        custom_value_handler=_percentage_handler,
+                    ),
                 ]
             if data.homekit.get("Totals_buy") is not None:
                 sensors += [
@@ -557,6 +663,62 @@ def sensor_options_for_data(
                         SensorDeviceClass.ENERGY,
                         UnitOfEnergy.KILO_WATT_HOUR,
                         SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-total-load-consumption",
+                        ["Totals_consumptionOfLoad"],
+                        "SEMS Total Load Consumption",
+                        SensorDeviceClass.ENERGY,
+                        UnitOfEnergy.KILO_WATT_HOUR,
+                        SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-total-self-use",
+                        ["Totals_selfUseOfPv"],
+                        "SEMS Total Self Use",
+                        SensorDeviceClass.ENERGY,
+                        UnitOfEnergy.KILO_WATT_HOUR,
+                        SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-total-battery-charge",
+                        ["Totals_charge"],
+                        "SEMS Total Battery Charge",
+                        SensorDeviceClass.ENERGY,
+                        UnitOfEnergy.KILO_WATT_HOUR,
+                        SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-total-battery-discharge",
+                        ["Totals_disCharge"],
+                        "SEMS Total Battery Discharge",
+                        SensorDeviceClass.ENERGY,
+                        UnitOfEnergy.KILO_WATT_HOUR,
+                        SensorStateClass.TOTAL_INCREASING,
+                    ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-total-self-sufficiency-rate",
+                        ["Totals_contributingRate"],
+                        "SEMS Total Self Sufficiency Rate",
+                        None,
+                        PERCENTAGE,
+                        SensorStateClass.MEASUREMENT,
+                        custom_value_handler=_percentage_handler,
+                    ),
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-total-self-use-rate",
+                        ["Totals_selfUseRate"],
+                        "SEMS Total Self Use Rate",
+                        None,
+                        PERCENTAGE,
+                        SensorStateClass.MEASUREMENT,
+                        custom_value_handler=_percentage_handler,
                     ),
                 ]
     return sensors

--- a/custom_components/sems/sensor.py
+++ b/custom_components/sems/sensor.py
@@ -58,11 +58,13 @@ def convert_status_to_label(status: Any) -> str:
 
 def _percentage_handler(value: Any, _data: dict[str, Any]) -> Any:
     """Convert a 0-1 ratio to a percentage."""
+    from decimal import InvalidOperation
+
     if value is None:
         return None
     try:
         return Decimal(str(value)) * 100
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, InvalidOperation):
         return value
 
 

--- a/custom_components/sems/sensor.py
+++ b/custom_components/sems/sensor.py
@@ -429,7 +429,7 @@ def sensor_options_for_data(
             get_value_from_path(data.inverters, [*path_to_inverter, "eChargeDay"])
             is not None
         ):
-            sensors += [
+            sensors.append(
                 SemsInverterSensorType(
                     device_info,
                     f"{serial_number}-eChargeDay",
@@ -439,6 +439,12 @@ def sensor_options_for_data(
                     UnitOfEnergy.KILO_WATT_HOUR,
                     SensorStateClass.TOTAL_INCREASING,
                 ),
+            )
+        if (
+            get_value_from_path(data.inverters, [*path_to_inverter, "eDischargeDay"])
+            is not None
+        ):
+            sensors.append(
                 SemsInverterSensorType(
                     device_info,
                     f"{serial_number}-eDischargeDay",
@@ -448,7 +454,7 @@ def sensor_options_for_data(
                     UnitOfEnergy.KILO_WATT_HOUR,
                     SensorStateClass.TOTAL_INCREASING,
                 ),
-            ]
+            )
         _LOGGER.debug(
             "Sensors for inverter %s: %s",
             redact_for_log(serial_number),
@@ -574,7 +580,7 @@ def sensor_options_for_data(
             ),
         ]
         if data.homekit.get(GOODWE_SPELLING.hasEnergyStatisticsCharts):
-            if data.homekit.get("Charts_buy") is not None:
+            if any(key.startswith("Charts_") for key in data.homekit):
                 sensors += [
                     SemsHomekitSensorType(
                         device_info,
@@ -651,7 +657,7 @@ def sensor_options_for_data(
                         custom_value_handler=_percentage_handler,
                     ),
                 ]
-            if data.homekit.get("Totals_buy") is not None:
+            if any(key.startswith("Totals_") for key in data.homekit):
                 sensors += [
                     SemsHomekitSensorType(
                         device_info,

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -304,6 +304,10 @@ async def test_exact_unique_ids_single_inverter_fixture(
         f"{sn}-vpv2",
         f"{sn}-vpv3",
         f"{sn}-vpv4",
+        # Per-inverter meter and energy data
+        f"{sn}-pmeter",
+        f"{sn}-eChargeDay",
+        f"{sn}-eDischargeDay",
     }
 
     ent_reg = er.async_get(hass)
@@ -392,6 +396,24 @@ async def test_exact_unique_ids_homekit_powerflow_fixture(
         f"{homekit_sn}-export-energy",
         f"{homekit_sn}-import-energy-total",
         f"{homekit_sn}-export-energy-total",
+        # Daily energy statistics
+        f"{homekit_sn}-daily-load-consumption",
+        f"{homekit_sn}-daily-self-use",
+        f"{homekit_sn}-daily-battery-charge",
+        f"{homekit_sn}-daily-battery-discharge",
+        f"{homekit_sn}-daily-self-sufficiency-rate",
+        f"{homekit_sn}-daily-self-use-rate",
+        # Total energy statistics
+        f"{homekit_sn}-total-load-consumption",
+        f"{homekit_sn}-total-self-use",
+        f"{homekit_sn}-total-battery-charge",
+        f"{homekit_sn}-total-battery-discharge",
+        f"{homekit_sn}-total-self-sufficiency-rate",
+        f"{homekit_sn}-total-self-use-rate",
+        # Per-inverter meter and energy data
+        f"{sn}-pmeter",
+        f"{sn}-eChargeDay",
+        f"{sn}-eDischargeDay",
     }
 
     ent_reg = er.async_get(hass)
@@ -547,6 +569,44 @@ async def test_homekit_powerflow_values_from_api_fixture(
     total_export_state = hass.states.get(total_export_entity_id)
     assert total_export_state is not None
     assert float(total_export_state.state) == 12901.2
+
+    # Verify daily load consumption sensor
+    daily_load_entity_id = ent_reg.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{homekit_sn}-daily-load-consumption"
+    )
+    assert daily_load_entity_id is not None
+    daily_load_state = hass.states.get(daily_load_entity_id)
+    assert daily_load_state is not None
+    assert float(daily_load_state.state) == 12.2
+    assert daily_load_state.attributes.get("unit_of_measurement") == "kWh"
+
+    # Verify daily self use sensor
+    daily_self_use_entity_id = ent_reg.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{homekit_sn}-daily-self-use"
+    )
+    assert daily_self_use_entity_id is not None
+    daily_self_use_state = hass.states.get(daily_self_use_entity_id)
+    assert daily_self_use_state is not None
+    assert float(daily_self_use_state.state) == 7.08
+
+    # Verify total load consumption sensor
+    total_load_entity_id = ent_reg.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{homekit_sn}-total-load-consumption"
+    )
+    assert total_load_entity_id is not None
+    total_load_state = hass.states.get(total_load_entity_id)
+    assert total_load_state is not None
+    assert float(total_load_state.state) == 7927.13
+
+    # Verify daily self-sufficiency rate (0.5803 → 58.03%)
+    daily_sufficiency_entity_id = ent_reg.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{homekit_sn}-daily-self-sufficiency-rate"
+    )
+    assert daily_sufficiency_entity_id is not None
+    daily_sufficiency_state = hass.states.get(daily_sufficiency_entity_id)
+    assert daily_sufficiency_state is not None
+    assert float(daily_sufficiency_state.state) == 58.03
+    assert daily_sufficiency_state.attributes.get("unit_of_measurement") == "%"
 
 
 def _build_homekit_test_data(


### PR DESCRIPTION
Expose additional data points from the SEMS API that were already available in the coordinator but not wired to sensor entities:

Daily energy statistics (from energeStatisticsCharts):
- Daily Load Consumption (consumptionOfLoad)
- Daily Self Use (selfUseOfPv)
- Daily Battery Charge/Discharge
- Daily Self Sufficiency Rate (contributingRate)
- Daily Self Use Rate (selfUseRate)

Lifetime energy statistics (from energeStatisticsTotals):
- Total Load Consumption, Self Use, Battery Charge/Discharge
- Total Self Sufficiency Rate, Self Use Rate

Per-inverter sensors (from invert_full, conditional):
- Grid Meter Power (pmeter)
- Battery Charge Today (eChargeDay)
- Battery Discharge Today (eDischargeDay)

Tests updated with new unique ID expectations and value assertions.