### PR TITLE
Issue 187 - ensure api response is handled ok if no inverters and only homekit

### DIFF
--- a/custom_components/sems/__init__.py
+++ b/custom_components/sems/__init__.py
@@ -36,7 +36,7 @@ class SemsRuntimeData:
     coordinator: SemsDataUpdateCoordinator
 
 
-SemsConfigEntry = ConfigEntry[SemsRuntimeData]
+type SemsConfigEntry = ConfigEntry[SemsRuntimeData]
 
 
 @dataclass(slots=True)
@@ -183,8 +183,8 @@ class SemsDataUpdateCoordinator(DataUpdateCoordinator[SemsData]):
                 # _LOGGER.debug("homeKit sn: %s", result["homKit"]["sn"])
                 # This seems more accurate than the Chart_sum
                 powerflow["all_time_generation"] = kpi.get("total_power")
-
-                homekit = powerflow
+#
+                hosmekit = powerflow
 
             if not inverters_by_sn and homekit is None:
                 raise UpdateFailed("No data available from API")
@@ -197,4 +197,4 @@ class SemsDataUpdateCoordinator(DataUpdateCoordinator[SemsData]):
 
 
 # Type alias to make type inference working for pylance
-SemsCoordinator = SemsDataUpdateCoordinator
+type sSemsCoordinator = SemsDataUpdateCoordinator

--- a/custom_components/sems/__init__.py
+++ b/custom_components/sems/__init__.py
@@ -36,7 +36,7 @@ class SemsRuntimeData:
     coordinator: SemsDataUpdateCoordinator
 
 
-type SemsConfigEntry = ConfigEntry[SemsRuntimeData]
+SemsConfigEntry = ConfigEntry[SemsRuntimeData]
 
 
 @dataclass(slots=True)
@@ -184,7 +184,7 @@ class SemsDataUpdateCoordinator(DataUpdateCoordinator[SemsData]):
                 # This seems more accurate than the Chart_sum
                 powerflow["all_time_generation"] = kpi.get("total_power")
 #
-                hosmekit = powerflow
+                homekit = powerflow
 
             if not inverters_by_sn and homekit is None:
                 raise UpdateFailed("No data available from API")
@@ -197,4 +197,4 @@ class SemsDataUpdateCoordinator(DataUpdateCoordinator[SemsData]):
 
 
 # Type alias to make type inference working for pylance
-type sSemsCoordinator = SemsDataUpdateCoordinator
+sSemsCoordinator = SemsDataUpdateCoordinator

--- a/custom_components/sems/__init__.py
+++ b/custom_components/sems/__init__.py
@@ -183,7 +183,7 @@ class SemsDataUpdateCoordinator(DataUpdateCoordinator[SemsData]):
                 # _LOGGER.debug("homeKit sn: %s", result["homKit"]["sn"])
                 # This seems more accurate than the Chart_sum
                 powerflow["all_time_generation"] = kpi.get("total_power")
-#
+                #
                 homekit = powerflow
 
             if not inverters_by_sn and homekit is None:
@@ -197,4 +197,4 @@ class SemsDataUpdateCoordinator(DataUpdateCoordinator[SemsData]):
 
 
 # Type alias to make type inference working for pylance
-sSemsCoordinator = SemsDataUpdateCoordinator
+SemsCoordinator = SemsDataUpdateCoordinator

--- a/custom_components/sems/__init__.py
+++ b/custom_components/sems/__init__.py
@@ -116,6 +116,9 @@ class SemsDataUpdateCoordinator(DataUpdateCoordinator[SemsData]):
                     "Error communicating with API: invalid inverter data. See debug logs."
                 )
 
+            if inverters is None:
+                inverters = []
+
             # Get Inverter Data
             for inverter in inverters:
                 inverter_full = inverter.get("invert_full")

--- a/custom_components/sems/__init__.py
+++ b/custom_components/sems/__init__.py
@@ -116,8 +116,7 @@ class SemsDataUpdateCoordinator(DataUpdateCoordinator[SemsData]):
                     "Error communicating with API: invalid inverter data. See debug logs."
                 )
 
-            if inverters is None:
-                inverters = []
+            inverters = inverters or []
 
             # Get Inverter Data
             for inverter in inverters:

--- a/custom_components/sems/__init__.py
+++ b/custom_components/sems/__init__.py
@@ -36,7 +36,7 @@ class SemsRuntimeData:
     coordinator: SemsDataUpdateCoordinator
 
 
-type SemsConfigEntry = ConfigEntry[SemsRuntimeData]
+SemsConfigEntry = ConfigEntry[SemsRuntimeData]
 
 
 @dataclass(slots=True)
@@ -111,9 +111,9 @@ class SemsDataUpdateCoordinator(DataUpdateCoordinator[SemsData]):
 
             inverters = result.get("inverter")
             inverters_by_sn: dict[str, dict[str, Any]] = {}
-            if not inverters or not isinstance(inverters, list):
+            if inverters is not None and not isinstance(inverters, list):
                 raise UpdateFailed(
-                    "Error communicating with API: invalid or missing inverter data. See debug logs."
+                    "Error communicating with API: invalid inverter data. See debug logs."
                 )
 
             # Get Inverter Data
@@ -184,6 +184,9 @@ class SemsDataUpdateCoordinator(DataUpdateCoordinator[SemsData]):
 
                 homekit = powerflow
 
+            if not inverters_by_sn and homekit is None:
+                raise UpdateFailed("No data available from API")
+
             data = SemsData(
                 inverters=inverters_by_sn, homekit=homekit, currency=currency
             )
@@ -192,4 +195,4 @@ class SemsDataUpdateCoordinator(DataUpdateCoordinator[SemsData]):
 
 
 # Type alias to make type inference working for pylance
-type SemsCoordinator = SemsDataUpdateCoordinator
+SemsCoordinator = SemsDataUpdateCoordinator

--- a/custom_components/sems/sensor.py
+++ b/custom_components/sems/sensor.py
@@ -4,12 +4,14 @@ For more details about this platform, please refer to the documentation at
 https://github.com/TimSoethout/goodwe-sems-home-assistant
 """
 
+from __future__ import annotations
+
 import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any
+from typing import Any, Union
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -47,7 +49,7 @@ from .device import device_info_for_inverter
 
 _LOGGER = logging.getLogger(__name__)
 
-type SemsValuePath = list[str | int]
+SemsValuePath = list[Union[str, int]]
 
 
 def convert_status_to_label(status: Any) -> str:

--- a/custom_components/sems/sensor.py
+++ b/custom_components/sems/sensor.py
@@ -561,6 +561,30 @@ def sensor_options_for_data(
                         SensorStateClass.TOTAL_INCREASING,
                     ),
                 ]
+            if data.homekit.get("Charts_sum") is not None:
+                sensors += [
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-generation",
+                        ["Charts_sum"],
+                        "SEMS Generation",
+                        SensorDeviceClass.ENERGY,
+                        UnitOfEnergy.KILO_WATT_HOUR,
+                        SensorStateClass.TOTAL_INCREASING,
+                    ),
+                ]
+            if data.homekit.get("Totals_sum") is not None:
+                sensors += [
+                    SemsHomekitSensorType(
+                        device_info,
+                        f"{homekit_sn}-generation-total",
+                        ["Totals_sum"],
+                        "SEMS Total Generation",
+                        SensorDeviceClass.ENERGY,
+                        UnitOfEnergy.KILO_WATT_HOUR,
+                        SensorStateClass.TOTAL_INCREASING,
+                    ),
+                ]
     return sensors
 
 

--- a/custom_components/sems/sensor.py
+++ b/custom_components/sems/sensor.py
@@ -11,7 +11,7 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, Union
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,

--- a/custom_components/sems/sensor.py
+++ b/custom_components/sems/sensor.py
@@ -49,7 +49,7 @@ from .device import device_info_for_inverter
 
 _LOGGER = logging.getLogger(__name__)
 
-SemsValuePath = list[Union[str, int]]
+SemsValuePath = list[str | int]
 
 
 def convert_status_to_label(status: Any) -> str:

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -552,6 +552,22 @@ async def test_homekit_powerflow_values_from_api_fixture(
     assert total_export_state is not None
     assert float(total_export_state.state) == 12901.2
 
+    generation_entity_id = ent_reg.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{homekit_sn}-generation"
+    )
+    assert generation_entity_id is not None
+    generation_state = hass.states.get(generation_entity_id)
+    assert generation_state is not None
+    assert float(generation_state.state) == 30.3
+
+    generation_total_entity_id = ent_reg.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{homekit_sn}-generation-total"
+    )
+    assert generation_total_entity_id is not None
+    generation_total_state = hass.states.get(generation_total_entity_id)
+    assert generation_total_state is not None
+    assert float(generation_total_state.state) == 16851.0
+
 
 async def test_homekit_only_api_response_without_inverter_data(
     hass: HomeAssistant,
@@ -648,7 +664,21 @@ async def test_homekit_only_api_response_without_inverter_data(
         ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-generation-total")
         is not None
     )
+    generation_entity_id = ent_reg.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{homekit_sn}-generation"
+    )
+    assert generation_entity_id is not None
+    generation_state = hass.states.get(generation_entity_id)
+    assert generation_state is not None
+    assert float(generation_state.state) == 0.43
 
+    generation_total_entity_id = ent_reg.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{homekit_sn}-generation-total"
+    )
+    assert generation_total_entity_id is not None
+    generation_total_state = hass.states.get(generation_total_entity_id)
+    assert generation_total_state is not None
+    assert float(generation_total_state.state) == 2315.36
     assert entry.state is ConfigEntryState.LOADED
 
 

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -704,7 +704,7 @@ async def test_homekit_only_api_response_with_none_inverter_data(
         "inverter": None,
         "kpi": {"currency": "EUR", "total_power": 123.4},
         "hasPowerflow": True,
-        "hasEnergeStatisticsCharts": False,
+        "hasEnergeStatisticsCharts": True,
         "homKit": {"sn": "HOMEKIT123", "homeKitLimit": False},
         "powerflow": {
             "pv": "0(W)",
@@ -718,6 +718,16 @@ async def test_homekit_only_api_response_with_none_inverter_data(
             "genset": "0(W)",
             "soc": 50,
         },
+        "energeStatisticsCharts": {
+            "sum": 0.43,
+            "buy": 0.37,
+            "sell": 0.99,
+        },
+        "energeStatisticsTotals": {
+            "sum": 2315.36,
+            "buy": 18605.64,
+            "sell": 5734.17,
+        },
     }
 
     with patch(
@@ -728,10 +738,61 @@ async def test_homekit_only_api_response_with_none_inverter_data(
         await hass.async_block_till_done()
 
     ent_reg = er.async_get(hass)
+    homekit_sn = "HOMEKIT123"
+
     assert (
-        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"HOMEKIT123-generation")
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-homekit")
         is not None
     )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-load")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-grid")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-pv")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-soc")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-battery")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-load-status")
+        is not None
+    )
+
+    # Check new generation sensors
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-generation")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-generation-total")
+        is not None
+    )
+    generation_entity_id = ent_reg.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{homekit_sn}-generation"
+    )
+    assert generation_entity_id is not None
+    generation_state = hass.states.get(generation_entity_id)
+    assert generation_state is not None
+    assert float(generation_state.state) == 0.43
+
+    generation_total_entity_id = ent_reg.async_get_entity_id(
+        Platform.SENSOR, DOMAIN, f"{homekit_sn}-generation-total"
+    )
+    assert generation_total_entity_id is not None
+    generation_total_state = hass.states.get(generation_total_entity_id)
+    assert generation_total_state is not None
+    assert float(generation_total_state.state) == 2315.36
 
 
 async def test_invalid_inverter_data_fails_setup_retry(

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -682,6 +682,134 @@ async def test_homekit_only_api_response_without_inverter_data(
     assert entry.state is ConfigEntryState.LOADED
 
 
+async def test_homekit_only_api_response_with_none_inverter_data(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+) -> None:
+    """Test that HomeKit-only responses work when inverter data is explicitly None."""
+    del enable_custom_integrations
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        data={
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_STATION_ID: MOCK_POWER_STATION_ID,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    payload = {
+        "inverter": None,
+        "kpi": {"currency": "EUR", "total_power": 123.4},
+        "hasPowerflow": True,
+        "hasEnergeStatisticsCharts": False,
+        "homKit": {"sn": "HOMEKIT123", "homeKitLimit": False},
+        "powerflow": {
+            "pv": "0(W)",
+            "pvStatus": 0,
+            "load": "100(W)",
+            "loadStatus": 1,
+            "grid": "100(W)",
+            "gridStatus": -1,
+            "bettery": "0(W)",
+            "betteryStatus": 0,
+            "genset": "0(W)",
+            "soc": 50,
+        },
+    }
+
+    with patch(
+        "custom_components.sems.sems_api.SemsApi.getData",
+        return_value=payload,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"HOMEKIT123-generation")
+        is not None
+    )
+
+
+async def test_invalid_inverter_data_fails_setup_retry(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+) -> None:
+    """Test setup retry when inverter data is not a list."""
+    del enable_custom_integrations
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        data={
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_STATION_ID: MOCK_POWER_STATION_ID,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    payload = {
+        "inverter": "invalid",
+        "kpi": {"currency": "EUR", "total_power": 0.0},
+        "hasPowerflow": False,
+        "hasEnergeStatisticsCharts": False,
+    }
+
+    with patch(
+        "custom_components.sems.sems_api.SemsApi.getData",
+        return_value=payload,
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_powerflow_invalid_payload_defaults_homekit_sn(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+) -> None:
+    """Test that invalid powerflow/homeKit payloads still create HomeKit sensors."""
+    del enable_custom_integrations
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        data={
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_STATION_ID: MOCK_POWER_STATION_ID,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    payload = {
+        "inverter": [],
+        "kpi": {"currency": "EUR", "total_power": 0.0},
+        "hasPowerflow": True,
+        "hasEnergeStatisticsCharts": False,
+        "homKit": None,
+        "powerflow": None,
+    }
+
+    with patch(
+        "custom_components.sems.sems_api.SemsApi.getData",
+        return_value=payload,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, "GW-HOMEKIT-NO-SERIAL-homekit")
+        is not None
+    )
+
+
 async def test_no_data_available_response_fails_setup(
     hass: HomeAssistant,
     enable_custom_integrations: None,

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -547,6 +548,119 @@ async def test_homekit_powerflow_values_from_api_fixture(
     total_export_state = hass.states.get(total_export_entity_id)
     assert total_export_state is not None
     assert float(total_export_state.state) == 12901.2
+
+
+async def test_homekit_only_api_response_without_inverter_data(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+) -> None:
+    """Test that HomeKit-only API responses work without inverter data."""
+    del enable_custom_integrations
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        data={
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_STATION_ID: MOCK_POWER_STATION_ID,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    payload = {
+        "kpi": {"currency": "EUR", "total_power": 123.4},
+        "hasPowerflow": True,
+        "hasEnergeStatisticsCharts": False,
+        "homKit": {"sn": "HOMEKIT123", "homeKitLimit": False},
+        "powerflow": {
+            "pv": "0(W)",
+            "pvStatus": 0,
+            "load": "100(W)",
+            "loadStatus": 1,
+            "grid": "100(W)",
+            "gridStatus": -1,
+            "bettery": "0(W)",
+            "betteryStatus": 0,
+            "genset": "0(W)",
+            "soc": 50,
+        },
+    }
+
+    with patch(
+        "custom_components.sems.sems_api.SemsApi.getData",
+        return_value=payload,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    ent_reg = er.async_get(hass)
+    homekit_sn = "HOMEKIT123"
+
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-homekit")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-load")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-grid")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-pv")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-soc")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-battery")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-load-status")
+        is not None
+    )
+
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_no_data_available_response_fails_setup(
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+) -> None:
+    """Test the coordinator fails setup when neither inverter nor HomeKit data is present."""
+    del enable_custom_integrations
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test",
+        data={
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_STATION_ID: MOCK_POWER_STATION_ID,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    payload = {
+        "kpi": {"currency": "EUR", "total_power": 0.0},
+        "hasPowerflow": False,
+        "hasEnergeStatisticsCharts": False,
+    }
+
+    with patch(
+        "custom_components.sems.sems_api.SemsApi.getData",
+        return_value=payload,
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 def _build_homekit_test_data(

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -393,6 +393,9 @@ async def test_exact_unique_ids_homekit_powerflow_fixture(
         f"{homekit_sn}-export-energy",
         f"{homekit_sn}-import-energy-total",
         f"{homekit_sn}-export-energy-total",
+        # Generation sensors
+        f"{homekit_sn}-generation",
+        f"{homekit_sn}-generation-total",
     }
 
     ent_reg = er.async_get(hass)

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -571,7 +571,7 @@ async def test_homekit_only_api_response_without_inverter_data(
     payload = {
         "kpi": {"currency": "EUR", "total_power": 123.4},
         "hasPowerflow": True,
-        "hasEnergeStatisticsCharts": False,
+        "hasEnergeStatisticsCharts": True,
         "homKit": {"sn": "HOMEKIT123", "homeKitLimit": False},
         "powerflow": {
             "pv": "0(W)",
@@ -584,6 +584,16 @@ async def test_homekit_only_api_response_without_inverter_data(
             "betteryStatus": 0,
             "genset": "0(W)",
             "soc": 50,
+        },
+        "energeStatisticsCharts": {
+            "sum": 0.43,
+            "buy": 0.37,
+            "sell": 0.99,
+        },
+        "energeStatisticsTotals": {
+            "sum": 2315.36,
+            "buy": 18605.64,
+            "sell": 5734.17,
         },
     }
 
@@ -623,6 +633,16 @@ async def test_homekit_only_api_response_without_inverter_data(
     )
     assert (
         ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-load-status")
+        is not None
+    )
+
+    # Check new generation sensors
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-generation")
+        is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id(Platform.SENSOR, DOMAIN, f"{homekit_sn}-generation-total")
         is not None
     )
 

--- a/tests/test_sensor_entities.py
+++ b/tests/test_sensor_entities.py
@@ -633,7 +633,7 @@ async def test_no_data_available_response_fails_setup(
     hass: HomeAssistant,
     enable_custom_integrations: None,
 ) -> None:
-    """Test the coordinator fails setup when neither inverter nor HomeKit data is present."""
+    """Test the coordinator retries setup when neither inverter nor HomeKit data is present."""
     del enable_custom_integrations
 
     entry = MockConfigEntry(
@@ -660,7 +660,7 @@ async def test_no_data_available_response_fails_setup(
         assert not await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 def _build_homekit_test_data(


### PR DESCRIPTION
# GoodWe SEMS: HomeKit-only response support

## Summary
Add support for SEMS API responses that contain `homeKit`/powerflow data but omit the `inverter` list. This makes the integration usable for HomeKit-only or meter-only GoodWe installations.

also re-added totals for generation as they seemed to be missing  ( see 2 with "Generation" in the name) 

## Testing
<img width="334" height="662" alt="image" src="https://github.com/user-attachments/assets/95670543-43fa-42dc-adb6-043cb3d28ac0" />




## Core change
- `custom_components/sems/__init__.py`
  - In `SemsDataUpdateCoordinator._async_update_data`:
    - changed validation from:
      - `if not inverters or not isinstance(inverters, list)`
    - to:
      - `if inverters is not None and not isinstance(inverters, list)`
  - Added fallback:
    - `if not inverters_by_sn and homekit is None: raise UpdateFailed("No data available from API")`

## Non-core / supporting updates
- `custom_components/sems/__init__.py`
  - fixed type alias:
    - `SemsConfigEntry = ConfigEntry[SemsRuntimeData]`
    - `SemsCoordinator = SemsDataUpdateCoordinator`
- `custom_components/sems/sensor.py`
  - added `from __future__ import annotations`
  - changed type alias from `type SemsValuePath = list[str | int]` to `SemsValuePath = list[Union[str, int]]`
- Validation checks run:
  - `ruff check custom_components/` => pass
  - `ruff format --check custom_components/` => pass
  - `mypy` run shows environment-related peripheral errors (Home Assistant stubs not present), no core syntax regression.

## Behavior impact
- If `inverter` is missing:
  - integration continues and returns HomeKit sensor set.
  - inverter-based sensors/switches are not created (no inverter data).
- If both `inverter` and `homekit` are missing:
  - `UpdateFailed` is raised (graceful failure).
